### PR TITLE
Fixed bailing out on empty lines.

### DIFF
--- a/applets/grep/grep.go
+++ b/applets/grep/grep.go
@@ -59,7 +59,7 @@ func doGrep(pattern *regexp.Regexp, fh io.Reader, fn string, print_fn bool) {
 			return
 		}
 		if line == "" {
-			break
+			continue
 		}
 
 		if pattern.MatchString(line) {


### PR DESCRIPTION
We were "return"ing on empty lines, but that's wrong. We want to skip empty lines and carry on with the next line.