### PR TITLE
builtin cd goes os.Getenv("HOME") if no args

### DIFF
--- a/applets/shell/builtins.go
+++ b/applets/shell/builtins.go
@@ -35,6 +35,14 @@ func pwd(call []string) error {
 }
 
 func cd(call []string) error {
+	if len(call) == 1 {
+		e := os.Chdir(os.Getenv("HOME"))
+		return e
+	}
+	if call[1] == "~" && len(call) == 2 {
+		e := os.Chdir(os.Getenv("HOME"))
+		return e
+	}
 	if len(call) != 2 {
 		return errors.New("`cd <directory>`")
 	}

--- a/applets/shell/builtins.go
+++ b/applets/shell/builtins.go
@@ -35,12 +35,19 @@ func pwd(call []string) error {
 }
 
 func cd(call []string) error {
+		homedir := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		if homedir == "" {
+				homedir = os.Getenv("USERPROFILE")
+		}
+		if homedir == "" {
+				homedir = os.Getenv("HOME")
+		}
 	if len(call) == 1 {
-		e := os.Chdir(os.Getenv("HOME"))
+		e := os.Chdir(homedir)
 		return e
 	}
 	if call[1] == "~" && len(call) == 2 {
-		e := os.Chdir(os.Getenv("HOME"))
+		e := os.Chdir(homedir)
 		return e
 	}
 	if len(call) != 2 {


### PR DESCRIPTION
Just type `cd` to go home. This probably doesn't work on Windows machines because the os.Getenv("HOME")..