### PR TITLE
shell applet: simplify built-in 'cd' and add variable expansion

### DIFF
--- a/applets/shell/builtins.go
+++ b/applets/shell/builtins.go
@@ -34,24 +34,25 @@ func pwd(call []string) error {
 	return nil
 }
 
+func homedir() string {
+	homedir := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+	if homedir == "" {
+		homedir = os.Getenv("USERPROFILE")
+	}
+	if homedir == "" {
+		homedir = os.Getenv("HOME")
+	}
+	return homedir
+}
+
 func cd(call []string) error {
-		homedir := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-		if homedir == "" {
-				homedir = os.Getenv("USERPROFILE")
-		}
-		if homedir == "" {
-				homedir = os.Getenv("HOME")
-		}
 	if len(call) == 1 {
-		e := os.Chdir(homedir)
+		e := os.Chdir(homedir())
 		return e
 	}
 	if call[1] == "~" && len(call) == 2 {
-		e := os.Chdir(homedir)
+		e := os.Chdir(homedir())
 		return e
-	}
-	if len(call) != 2 {
-		return errors.New("`cd <directory>`")
 	}
 	e := os.Chdir(call[1])
 	return e

--- a/applets/shell/shell.go
+++ b/applets/shell/shell.go
@@ -2,10 +2,11 @@ package shell
 
 import (
 	"fmt"
-	"github.com/surma/gobox/pkg/common"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/surma/gobox/pkg/common"
 )
 
 func Shell(call []string) error {
@@ -39,6 +40,7 @@ func Shell(call []string) error {
 		if isComment(line) {
 			continue
 		}
+		line = expandVariables(line)
 		params, ce := common.Parameterize(line)
 		if ce != nil {
 			common.DumpError(ce)
@@ -51,6 +53,23 @@ func Shell(call []string) error {
 		}
 	}
 	return nil
+}
+
+func expandVariables(line string) string {
+	var expanded []string
+	var isquote bool
+	words := strings.Split(line, " ")
+	for _, word := range words {
+		isquote = false
+		if strings.HasPrefix(word, `'`) {
+			isquote = true
+		}
+		if !isquote && strings.HasPrefix(word, "$") {
+			word = os.ExpandEnv(word)
+		}
+		expanded = append(expanded, word)
+	}
+	return strings.Join(expanded, " ")
 }
 
 func isComment(line string) bool {


### PR DESCRIPTION
only retrieving $HOME if needed