### PR TITLE
Add alias 'sh' for 'shell' applet

### DIFF
--- a/applets.go
+++ b/applets.go
@@ -27,7 +27,7 @@ import (
 var Applets map[string]Applet = map[string]Applet{
 	"echo":    echo.Echo,
 	"shell":   shell.Shell,
-	"sh":   shell.Shell,
+	"sh":      shell.Shell,
 	"telnetd": telnetd.Telnetd,
 	"ls":      ls.Ls,
 	"rm":      rm.Rm,

--- a/applets.go
+++ b/applets.go
@@ -27,6 +27,7 @@ import (
 var Applets map[string]Applet = map[string]Applet{
 	"echo":    echo.Echo,
 	"shell":   shell.Shell,
+	"sh":   shell.Shell,
 	"telnetd": telnetd.Telnetd,
 	"ls":      ls.Ls,
 	"rm":      rm.Rm,


### PR DESCRIPTION
To allow /bin/sh installation, otherwise gobox complains ```no applet "sh"```

Shows up in list of applets like this:
```
List of compiled applets:

httpd, kill, cat, umount, mkdir, grep, echo, sh, chroot, ps, head, telnetd, ls, gunzip, gobox, mount, gzip, wget, mknod, zcat, shell, rm, 
```
