### PR TITLE
mount applet: when called with no args, try /proc/mounts

### DIFF
--- a/applets/mount/mount_linux.go
+++ b/applets/mount/mount_linux.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"strings"
 	"syscall"
+	"io/ioutil"
 )
 
 var (
@@ -20,7 +21,19 @@ func Mount(call []string) error {
 		return e
 	}
 
-	if flagSet.NArg() != 2 || *helpFlag {
+	if flagSet.NArg() < 1 && !*helpFlag {
+		mountinfo, err := ioutil.ReadFile("/etc/mtab")
+		if err != nil {
+			mountinfo, err = ioutil.ReadFile("/proc/mounts")
+			if err != nil {
+				return err
+			}
+		}
+		print(string(mountinfo))
+		return nil	
+	}
+	
+	if *helpFlag {
 		println("`mount` [options] <device> <dir>")
 		flagSet.PrintDefaults()
 		println("\nAvailable options are:")

--- a/applets/mount/mount_linux.go
+++ b/applets/mount/mount_linux.go
@@ -22,25 +22,31 @@ func Mount(call []string) error {
 	}
 
 	if flagSet.NArg() < 1 && !*helpFlag {
+
+		// try mtab
 		mountinfo, err := ioutil.ReadFile("/etc/mtab")
 		if err != nil {
+		
+			// try procfs
 			mountinfo, err = ioutil.ReadFile("/proc/mounts")
+
 			if err != nil {
+				if strings.Contains(err.Error(), "such file"){
+					println("mount: no /etc/mtab, no /proc/mounts")
+					showHelp()
+					return nil					
+				} else {
 				return err
+				}
 			}
+
 		}
 		print(string(mountinfo))
 		return nil	
 	}
 	
 	if *helpFlag {
-		println("`mount` [options] <device> <dir>")
-		flagSet.PrintDefaults()
-		println("\nAvailable options are:")
-		for opt := range flagMap {
-			print(opt, ", ")
-		}
-		println()
+		showHelp()
 		return nil
 	}
 
@@ -79,4 +85,14 @@ func parseFlags() (uint32, error) {
 		ret |= val
 	}
 	return ret, nil
+}
+
+func showHelp(){
+		println("`mount` [options] <device> <dir>")
+		flagSet.PrintDefaults()
+		println("\nAvailable options are:")
+		for opt := range flagMap {
+			print(opt, ", ")
+		}
+		println()
 }


### PR DESCRIPTION
**Without mtab or procfs**, calling 'mount' with no arguments will print ```no /etc/mtab, no /proc/mounts``` and usage.

**With mtab or procfs**, calling 'mount' with no arguments will print mount info. Trying /etc/mtab first, then /proc/mounts if mtab doesn't exist.